### PR TITLE
PR: Show all trails & Filter Implementation

### DIFF
--- a/components/Filter.tsx
+++ b/components/Filter.tsx
@@ -30,7 +30,9 @@ function startFilter<trailProps>(
   function isRequested(trail: Trail) {
     return (
       (!locationVal ||
-        trail.name.toLowerCase().includes(locationVal.toLowerCase())) &&
+        trail.name.toLowerCase().includes(locationVal.toLowerCase()) ||
+        !locationVal ||
+        trail.prefecture.toLowerCase().includes(locationVal.toLowerCase())) &&
       (!lengthVal ||
         (trail.length >= lengthVal[0] && trail.length <= lengthVal[1])) &&
       (!difficultyVal || parseInt(difficultyVal) === trail.difficulty)
@@ -89,7 +91,7 @@ export const Filter: React.FC<filterProps> = ({ trails, setTrail }) => {
 
         <TextField
           id="demo-helper-text-aligned"
-          label="Trail Name"
+          label="Keyword"
           onChange={handleLocChange}
           sx={{ mb: 2 }}
         />

--- a/pages/prefectures.tsx
+++ b/pages/prefectures.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useRouter } from "next/router";
+import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { useAuthContext } from "../components/context/UseAuthContext";
 import { Container } from "@mui/material";
@@ -148,9 +149,17 @@ const prefectures = () => {
   }, []);
 
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="lg" sx={{ mt: 10 }}>
       <div className="bg__map">
         <h1>Where do you want to walk next?</h1>
+        <Link
+          href={{
+            pathname: "trails/[pref]",
+            query: { pref: "all" },
+          }}
+        >
+          Not sure about where to go? See all trails
+        </Link>
         <div id="my-map-container"></div>
       </div>
     </Container>

--- a/pages/prefectures.tsx
+++ b/pages/prefectures.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useState, useEffect, useRef } from "react";
-import { useAuthContext } from "../components/context/UseAuthContext";
+import { useEffect, useRef } from "react";
 import { Container } from "@mui/material";
+import styles from "../styles/prefectures.module.css";
 
 const engPrefNames = {
   北海道: "Hokkaido",
@@ -153,12 +153,16 @@ const prefectures = () => {
       <div className="bg__map">
         <h1>Where do you want to walk next?</h1>
         <Link
+          className={styles.link__all}
           href={{
             pathname: "trails/[pref]",
             query: { pref: "all" },
           }}
         >
-          Not sure about where to go? See all trails
+          <h2 className={styles.txt__link}>
+            {" "}
+            Not sure where to go?🤔 See all trails
+          </h2>
         </Link>
         <div id="my-map-container"></div>
       </div>

--- a/pages/trails/[pref].tsx
+++ b/pages/trails/[pref].tsx
@@ -27,11 +27,16 @@ function GetTrailData() {
 const ResultList = () => {
   const router = useRouter();
   const { pref } = router.query;
+  console.log(pref);
   const allTrails = GetTrailData() || [];
 
   const capitalizePref = _.capitalize(pref);
   const filteredTrails = allTrails.filter((trail: Trail) => {
-    return pref === trail.prefecture;
+    if (pref === "all") {
+      return allTrails;
+    } else {
+      return pref === trail.prefecture;
+    }
   });
 
   const [trailsArr, setTrail] = useState<Trail[] | []>(filteredTrails);
@@ -42,8 +47,8 @@ const ResultList = () => {
 
   return (
     <>
-      <Container maxWidth="lg">
-        <h1>Trails in {capitalizePref}</h1>
+      <Container maxWidth="lg" sx={{ mt: 10 }}>
+        <h1>{capitalizePref} Trails</h1>
         <BrowserView>
           <Container>
             <div className={styles.flex_container}>

--- a/styles/prefectures.css
+++ b/styles/prefectures.css
@@ -1,1 +1,0 @@
-/*# sourceMappingURL=prefectures.css.map */

--- a/styles/prefectures.css.map
+++ b/styles/prefectures.css.map
@@ -1,1 +1,0 @@
-{"version":3,"sources":[],"names":[],"mappings":"","file":"prefectures.css"}

--- a/styles/prefectures.module.css
+++ b/styles/prefectures.module.css
@@ -1,0 +1,6 @@
+.link__all {
+  text-decoration: none;
+}
+.link__all h2 {
+  margin-top: 1rem;
+}/*# sourceMappingURL=prefectures.module.css.map */

--- a/styles/prefectures.module.css.map
+++ b/styles/prefectures.module.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["prefectures.module.scss","prefectures.module.css"],"names":[],"mappings":"AAAA;EACE,qBAAA;ACCF;ADCE;EACE,gBAAA;ACCJ","file":"prefectures.module.css"}

--- a/styles/prefectures.module.scss
+++ b/styles/prefectures.module.scss
@@ -1,0 +1,8 @@
+.link__all {
+  text-decoration: none;
+
+  h2 {
+    margin-top: 1rem;
+    // color: red;
+  }
+}


### PR DESCRIPTION
## Summary
- In prefecture map page, added a link to go to the result page with all trails
- Modified a filter component and made it possible to sort either prefecture or trail name

- Have not modified the link color

## Checklist
- [x] I checked npm run build locally and successfully built

Prefecture
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/83695925/208227560-5ea3b1c3-3527-40e3-ab4d-6303f84a1efe.png">

Result
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/83695925/208227516-c507dddb-8f4d-4972-a3a7-65450b4845c9.png">


