### PR TITLE
PR: Hotfix for Interactive Map Trail Messages

### DIFF
--- a/components/LargeMap.tsx
+++ b/components/LargeMap.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import L from "leaflet";
 import styles from "../styles/mapview.module.css";
+import MessageIcon from "./MessageIcon";
 
 type MessageDataObject = {
   id: number;
@@ -31,6 +32,7 @@ const LargeMap = ({
   setIsSubmitted,
   currentPosition,
   setCurrentPosition,
+  setRatingOpen,
 }) => {
   const latNumber = parseFloat(lat);
   const lonNumber = parseFloat(lon);
@@ -108,7 +110,10 @@ const LargeMap = ({
             position={[messageLatNumber, messageLonNumber]}
             icon={messageIcon}
           >
-            <Popup>{message.message}</Popup>
+            <Popup>
+              {message.message}{" "}
+              <MessageIcon message={message} setRatingOpen={setRatingOpen} />
+            </Popup>
           </Marker>
         );
       })}

--- a/components/LargeMap.tsx
+++ b/components/LargeMap.tsx
@@ -19,8 +19,6 @@ type MessageDataObject = {
   latitude: string;
   longitude: string;
   message: string;
-  likes: number;
-  dislikes: number;
   date: string;
 };
 

--- a/components/LargeMap.tsx
+++ b/components/LargeMap.tsx
@@ -32,7 +32,7 @@ const LargeMap = ({
   setIsSubmitted,
   currentPosition,
   setCurrentPosition,
-  setRatingOpen,
+  setMessageDetails,
 }) => {
   const latNumber = parseFloat(lat);
   const lonNumber = parseFloat(lon);
@@ -112,7 +112,7 @@ const LargeMap = ({
           >
             <Popup>
               {message.message}{" "}
-              <MessageIcon message={message} setRatingOpen={setRatingOpen} />
+              <MessageIcon message={message} setMessageDetails={setMessageDetails} />
             </Popup>
           </Marker>
         );

--- a/components/MessageDetails.tsx
+++ b/components/MessageDetails.tsx
@@ -1,9 +1,18 @@
+import { useEffect } from "react";
+
 interface MessageRatingProps {
-  ratingOpen: Object;
-  setRatingOpen: Function;
+  messageDetails: Object;
+  setMessageDetails: Function;
 }
 
-const MessageDetails = ({ ratingOpen, setRatingOpen }: MessageRatingProps) => {
+const MessageDetails = ({
+  messageDetails,
+  setMessageDetails,
+}: MessageRatingProps) => {
+  useEffect(() => {
+    console.log(messageDetails);
+  }, [messageDetails]);
+
   return <>Test</>;
 };
 

--- a/components/MessageDetails.tsx
+++ b/components/MessageDetails.tsx
@@ -1,19 +1,47 @@
 import { useEffect } from "react";
+import { Modal, Box, Typography } from "@mui/material";
 
 interface MessageRatingProps {
   messageDetails: Object;
   setMessageDetails: Function;
 }
 
+const style = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+  cursor: "pointer",
+};
+
 const MessageDetails = ({
   messageDetails,
   setMessageDetails,
 }: MessageRatingProps) => {
-  useEffect(() => {
-    console.log(messageDetails);
-  }, [messageDetails]);
+  const handleClose = () => {
+    setMessageDetails(messageDetails["selected"] === false);
+  };
 
-  return <>Test</>;
+  return (
+    <Modal
+      keepMounted
+      open={messageDetails["selected"] === true}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box sx={style}>
+        <Typography>{messageDetails["data"]["message"]}</Typography>
+      </Box>
+    </Modal>
+  );
 };
 
 export default MessageDetails;

--- a/components/MessageDetails.tsx
+++ b/components/MessageDetails.tsx
@@ -30,12 +30,14 @@ const MessageDetails = ({
       selected: "false",
       data: {
         message: null,
-        likes: null,
-        dislikes: null,
         date: null,
       },
     });
   };
+
+  const fetchUserLikeData = () => {};
+
+  useEffect(() => {}, [messageDetails["selected"] === true]);
 
   return (
     <Modal
@@ -47,8 +49,6 @@ const MessageDetails = ({
     >
       <Box sx={style}>
         <Typography>{messageDetails["data"]["message"]}</Typography>
-        <Typography>Likes: {messageDetails["data"]["likes"]}</Typography>
-        <Typography>Dislikes: {messageDetails["data"]["dislikes"]}</Typography>
         <Typography>Date: {messageDetails["data"]["date"]}</Typography>
       </Box>
     </Modal>

--- a/components/MessageDetails.tsx
+++ b/components/MessageDetails.tsx
@@ -26,7 +26,15 @@ const MessageDetails = ({
   setMessageDetails,
 }: MessageRatingProps) => {
   const handleClose = () => {
-    setMessageDetails(messageDetails["selected"] === false);
+    setMessageDetails({
+      selected: "false",
+      data: {
+        message: null,
+        likes: null,
+        dislikes: null,
+        date: null,
+      },
+    });
   };
 
   return (
@@ -39,6 +47,9 @@ const MessageDetails = ({
     >
       <Box sx={style}>
         <Typography>{messageDetails["data"]["message"]}</Typography>
+        <Typography>Likes: {messageDetails["data"]["likes"]}</Typography>
+        <Typography>Dislikes: {messageDetails["data"]["dislikes"]}</Typography>
+        <Typography>Date: {messageDetails["data"]["date"]}</Typography>
       </Box>
     </Modal>
   );

--- a/components/MessageDetails.tsx
+++ b/components/MessageDetails.tsx
@@ -1,0 +1,10 @@
+interface MessageRatingProps {
+  ratingOpen: Object;
+  setRatingOpen: Function;
+}
+
+const MessageDetails = ({ ratingOpen, setRatingOpen }: MessageRatingProps) => {
+  return <>Test</>;
+};
+
+export default MessageDetails;

--- a/components/MessageForm.tsx
+++ b/components/MessageForm.tsx
@@ -8,8 +8,8 @@ import { useAuthContext } from "./context/UseAuthContext";
 interface MessageFormProps {
   trailID: number;
   currentPosition: Object;
-  open: boolean;
-  setOpen: Function;
+  formOpen: boolean;
+  setFormOpen: Function;
   setIsSubmitted: Function;
 }
 
@@ -31,8 +31,8 @@ const style = {
 const MessageForm = ({
   trailID,
   currentPosition,
-  open,
-  setOpen,
+  formOpen,
+  setFormOpen,
   setIsSubmitted,
 }: MessageFormProps) => {
   const [value, setValue] = useState<string>("");
@@ -41,7 +41,7 @@ const MessageForm = ({
 
   const handleClose = () => {
     setError(false);
-    setOpen(false);
+    setFormOpen(false);
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -93,7 +93,7 @@ const MessageForm = ({
   return (
     <Modal
       keepMounted
-      open={open}
+      open={formOpen}
       onClose={handleClose}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"

--- a/components/MessageForm.tsx
+++ b/components/MessageForm.tsx
@@ -63,8 +63,6 @@ const MessageForm = ({
         trail_id: trailID,
         latitude: currentPosition["lat"],
         longitude: currentPosition["lng"],
-        likes: 0,
-        dislikes: 0,
         message: value,
         date: `${current.getFullYear()}-${
           current.getMonth() + 1

--- a/components/MessageIcon.tsx
+++ b/components/MessageIcon.tsx
@@ -12,8 +12,6 @@ const MessageIcon = ({ message, setMessageDetails }: MessageIconProps) => {
       selected: true,
       data: {
         message: message["message"],
-        likes: message["likes"],
-        dislikes: message["dislikes"],
         date: message["date"],
       },
     });

--- a/components/MessageIcon.tsx
+++ b/components/MessageIcon.tsx
@@ -1,0 +1,21 @@
+import { IconButton } from "@mui/material";
+import MoreIcon from "@mui/icons-material/More";
+
+interface MessageIconProps {
+  message: Object;
+  setRatingOpen: Function;
+}
+
+const MessageIcon = ({ message, setRatingOpen }: MessageIconProps) => {
+  const Console = () => {
+    console.log(message);
+  };
+
+  return (
+    <IconButton onClick={Console}>
+      <MoreIcon />
+    </IconButton>
+  );
+};
+
+export default MessageIcon;

--- a/components/MessageIcon.tsx
+++ b/components/MessageIcon.tsx
@@ -3,16 +3,24 @@ import MoreIcon from "@mui/icons-material/More";
 
 interface MessageIconProps {
   message: Object;
-  setRatingOpen: Function;
+  setMessageDetails: Function;
 }
 
-const MessageIcon = ({ message, setRatingOpen }: MessageIconProps) => {
-  const Console = () => {
-    console.log(message);
+const MessageIcon = ({ message, setMessageDetails }: MessageIconProps) => {
+  const handleMessageDetails = () => {
+    setMessageDetails({
+      selected: true,
+      data: {
+        message: message["message"],
+        likes: message["likes"],
+        dislikes: message["dislikes"],
+        date: message["date"],
+      },
+    });
   };
 
   return (
-    <IconButton onClick={Console}>
+    <IconButton onClick={handleMessageDetails}>
       <MoreIcon />
     </IconButton>
   );

--- a/components/MessageRating.tsx
+++ b/components/MessageRating.tsx
@@ -1,7 +1,0 @@
-const MessageRating = () => {
-    return (
-        <></>
-    )
-}
-
-export default MessageRating;

--- a/components/MessageRating.tsx
+++ b/components/MessageRating.tsx
@@ -1,0 +1,7 @@
+const MessageRating = () => {
+    return (
+        <></>
+    )
+}
+
+export default MessageRating;

--- a/components/MessageThumbUp.tsx
+++ b/components/MessageThumbUp.tsx
@@ -1,0 +1,8 @@
+import ThumbUpOutlinedIcon from '@mui/icons-material/ThumbUpOutlined';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+
+const MessageThumbUp = () => {
+    
+}
+
+export default MessageThumbUp;

--- a/pages/mapview.tsx
+++ b/pages/mapview.tsx
@@ -16,7 +16,7 @@ import MessageIcon from "@mui/icons-material/Message";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import { LargeMap } from "../components";
 import MessageForm from "../components/MessageForm";
-import MessageRating from "../components/MessageRating";
+import MessageRating from "../components/MessageDetails";
 
 type LatLngObject = {
   lat: number | null;
@@ -36,6 +36,15 @@ const MapView = () => {
   });
   const [formOpen, setFormOpen] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
+  const [ratingOpen, setRatingOpen] = useState<Object>({
+    selected: false,
+    data: {
+      message: null,
+      likes: null,
+      dislikes: null,
+      date: null,
+    },
+  });
 
   const successCallback = (position: object) => {
     setCurrentPosition({
@@ -98,6 +107,7 @@ const MapView = () => {
         setIsSubmitted={setIsSubmitted}
         currentPosition={currentPosition}
         setCurrentPosition={setCurrentPosition}
+        setRatingOpen={setRatingOpen}
       />
       <SpeedDial
         ariaLabel="SpeedDial basic example"
@@ -120,7 +130,7 @@ const MapView = () => {
         setFormOpen={setFormOpen}
         setIsSubmitted={setIsSubmitted}
       />
-      <MessageRating />
+      {/* <MessageRating ratingOpen={ratingOpen} setRatingOpen={setRatingOpen} /> */}
     </Box>
   );
 };

--- a/pages/mapview.tsx
+++ b/pages/mapview.tsx
@@ -40,8 +40,6 @@ const MapView = () => {
     selected: false,
     data: {
       message: null,
-      likes: null,
-      dislikes: null,
       date: null,
     },
   });

--- a/pages/mapview.tsx
+++ b/pages/mapview.tsx
@@ -16,6 +16,7 @@ import MessageIcon from "@mui/icons-material/Message";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import { LargeMap } from "../components";
 import MessageForm from "../components/MessageForm";
+import MessageRating from "../components/MessageRating";
 
 type LatLngObject = {
   lat: number | null;
@@ -33,7 +34,7 @@ const MapView = () => {
     lat: null,
     lng: null,
   });
-  const [open, setOpen] = useState<boolean>(false);
+  const [formOpen, setFormOpen] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
 
   const successCallback = (position: object) => {
@@ -63,7 +64,7 @@ const MapView = () => {
     {
       name: "Write Message",
       icon: <MessageIcon />,
-      onclick: () => setOpen(true),
+      onclick: () => setFormOpen(true),
     },
   ];
 
@@ -115,10 +116,11 @@ const MapView = () => {
       <MessageForm
         trailID={trailID}
         currentPosition={currentPosition}
-        open={open}
-        setOpen={setOpen}
+        formOpen={formOpen}
+        setFormOpen={setFormOpen}
         setIsSubmitted={setIsSubmitted}
       />
+      <MessageRating />
     </Box>
   );
 };

--- a/pages/mapview.tsx
+++ b/pages/mapview.tsx
@@ -16,7 +16,7 @@ import MessageIcon from "@mui/icons-material/Message";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import { LargeMap } from "../components";
 import MessageForm from "../components/MessageForm";
-import MessageRating from "../components/MessageDetails";
+import MessageDetails from "../components/MessageDetails";
 
 type LatLngObject = {
   lat: number | null;
@@ -36,7 +36,7 @@ const MapView = () => {
   });
   const [formOpen, setFormOpen] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
-  const [ratingOpen, setRatingOpen] = useState<Object>({
+  const [messageDetails, setMessageDetails] = useState<Object>({
     selected: false,
     data: {
       message: null,
@@ -107,7 +107,7 @@ const MapView = () => {
         setIsSubmitted={setIsSubmitted}
         currentPosition={currentPosition}
         setCurrentPosition={setCurrentPosition}
-        setRatingOpen={setRatingOpen}
+        setMessageDetails={setMessageDetails}
       />
       <SpeedDial
         ariaLabel="SpeedDial basic example"
@@ -130,7 +130,10 @@ const MapView = () => {
         setFormOpen={setFormOpen}
         setIsSubmitted={setIsSubmitted}
       />
-      {/* <MessageRating ratingOpen={ratingOpen} setRatingOpen={setRatingOpen} /> */}
+      <MessageDetails
+        messageDetails={messageDetails}
+        setMessageDetails={setMessageDetails}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
# Summary
Recent changes in the `hikeable-backend` repository broke `POST` requests for interactive map messages. This PR addresses those errors by removing the `likes` and `dislikes` properties from the `messageObject` props/interface.